### PR TITLE
Added the ability to store message templates in S3, and also fixed up typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,86 @@ publish the templates to s3
 ```bash
 cfpublish sftp --version latest
 ```
+
+## Using an S3 file for the message content
+
+You need to change the IAM policy given to the CreateDynamicSftpUser script, by adding the following into sftp.config.yaml
+```
+dynamic_users_create_and_cleanup: 
+  custom_policies:
+    s3get:
+      action:
+        - s3:GetObject
+      resource: 'arn:aws:s3:::BUCKET-NAME/message.html'
+    createuser-iam:
+      action:
+        - iam:GetRole
+        - iam:CreateRole
+        - iam:AttachRolePolicy
+        - iam:PutRolePolicy
+        - iam:CreatePolicy*
+      resource:
+        - Fn::Sub: arn:aws:iam::${AWS::AccountId}:role/*
+        - Fn::Sub: arn:aws:iam::${AWS::AccountId}:policy/*
+    createuser-secretsmanager:
+      action:
+        - secretsmanager:GetSecretValue
+        - secretsmanager:DescribeSecret
+        - secretsmanager:RestoreSecret
+        - secretsmanager:PutSecretValue
+        - secretsmanager:CreateSecret
+      resource:
+        Fn::Sub: arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*
+    createuser-getrandompassword:
+      action: secretsmanager:GetRandomPassword
+    createuser-snspublish:
+      action: sns:Publish
+      resource:
+        Ref: DynamicSftpUserCreatedTopic
+    cleanupusers-iam:
+      action:
+        - iam:DeleteRolePolicy
+        - iam:DeleteRole
+        - iam:ListRolePolicies
+      resource:
+        Fn::Sub: arn:aws:iam::${AWS::AccountId}:role/*SftpAccessRole
+    cleanupusers-secretsmanager:
+      action:
+        - secretsmanager:GetSecretValue
+        - secretsmanager:DeleteSecret
+      resource: 
+        Fn::Sub: arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sftp/${EnvironmentName}/*
+    cleanupusers-listsecrets:
+      action: secretsmanager:ListSecrets
+  roles:
+    CreateDynamicSftpUser:
+      policies_inline:
+        - cloudwatch-logs
+        - createuser-iam
+        - createuser-secretsmanager
+        - createuser-getrandompassword
+        - createuser-snspublish
+        - s3get
+    CleanupDynamicSftpUsers:
+      policies_inline:
+        - cloudwatch-logs
+        - cleanupusers-iam
+        - cleanupusers-secretsmanager
+        - cleanupusers-listsecrets
+
+```
+
+Then add the following parameter when calling the SFTP component:
+
+```
+CfhighlanderTemplate do
+  Component name: 'sftp', template: 'sftp', conditional: true do
+    parameter name: 'BucketName', value: cfout('s3.Snapshot')
+    parameter name: 'S3Message', value: 'BUCKET-NAME/message.html'
+  end
+  Component 's3'
+  Component 's3-cleanup-on-delete', dependson: ['s3'] do
+    parameter name: 'Buckets', value: cfout('s3.Snapshot')
+  end
+end
+```

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ publish the templates to s3
 cfpublish sftp --version latest
 ```
 
-## Using an S3 file for the message content
+## Using an S3 file for the message content sent to SNS via CreateDynamicSftpUser
 
-You need to change the IAM policy given to the CreateDynamicSftpUser script, by adding the following into sftp.config.yaml
+You need to change the IAM policy given to the CreateDynamicSftpUser script, by adding the following into sftp.config.yaml (note the s3get policy)
 ```
 dynamic_users_create_and_cleanup: 
   custom_policies:
@@ -146,3 +146,5 @@ CfhighlanderTemplate do
   end
 end
 ```
+
+Now when the Lambda is called, it will use the template file stored in S3 as the message that is sent to SNS.

--- a/lambdas/create_dynamic_sftp_user/index.py
+++ b/lambdas/create_dynamic_sftp_user/index.py
@@ -11,6 +11,7 @@ from datetime import timedelta, datetime, timezone
 iam = boto3.client('iam')
 secretsmanager = boto3.client('secretsmanager')
 sns = boto3.client('sns')
+s3 = boto3.resource('s3')
 
 def role_exists(role_name: str) -> bool:  
   try:
@@ -199,8 +200,17 @@ def handler(event, context):
       raise Exception(f'Failed to create secrets manager secret sftp/{environment_name}/{msg["username"]}')
 
   user_created_sns_topic = os.environ['USER_CREATED_SNS_TOPIC']
+  if os.environ['MESSAGE_S3_PATH'] != '':
+    s3env = os.environ['MESSAGE_S3_PATH'].replace('s3://','')
+    bucketName = s3env.split('/')[0]
+    filePath = s3env.split('/')[1]
+    object = s3.Object(bucketName, filePath)
+    messageContent = object.get()['Body'].read().decode('utf-8')
+  else:
+    messageContent = f'Temporary sftp user \'{msg["username"]}\' was successfully created. Password is <{secret_string["Password"]}>'
+    
   sns.publish(
     TopicArn = user_created_sns_topic,
-    Message = f'Temporary sftp user \'{msg["username"]}\' was successfully created. Password is <{secret_string["Password"]}>'
+    Message = messageContent
   )
   return

--- a/sftp.cfhighlander.rb
+++ b/sftp.cfhighlander.rb
@@ -5,6 +5,7 @@ CfhighlanderTemplate do
     ComponentParam 'EnvironmentType', 'development', allowedValues: ['development','production'], isGlobal: true
     ComponentParam 'DnsDomain', ''
     ComponentParam 'EnableTransferServer', 'true', allowedValues: ['true','false']
+    ComponentParam 'S3Message', ''
     if endpoint.upcase == 'VPC_ENDPOINT' || endpoint.upcase == 'VPC'
       ComponentParam 'VpcId', type: 'AWS::EC2::VPC::Id'
       ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
@@ -20,7 +21,7 @@ CfhighlanderTemplate do
     end
   end
 
-  LambdaFunctions 'apigateway_identity_providor' if identity_provider.upcase == 'API_GATEWAY'
+  LambdaFunctions 'apigateway_identity_provider' if identity_provider.upcase == 'API_GATEWAY'
   LambdaFunctions 'output_vpc_endpoint_ips_custom_resource' if output_vpc_endpoint_ips
   LambdaFunctions 'dynamic_users_create_and_cleanup' if identity_provider.upcase == 'API_GATEWAY' and dynamic_users
 end

--- a/sftp.cfndsl.rb
+++ b/sftp.cfndsl.rb
@@ -15,11 +15,11 @@ CloudFormation do
     default_tags << { Key: key, Value: value }
   end
 
-  # Create the resources required for the apigateway identity providor
+  # Create the resources required for the apigateway identity provider
   if identity_provider.upcase == 'API_GATEWAY'
 
     ApiGateway_RestApi(:CustomIdentityProviderApi) {
-      Name FnSub("${EnvironmentName}-sftp-custom-identity-providor")
+      Name FnSub("${EnvironmentName}-sftp-custom-identity-provider")
       FailOnWarnings true
       EndpointConfiguration({
         Types: ['REGIONAL']
@@ -118,9 +118,9 @@ CloudFormation do
       StageName FnSub('${EnvironmentName}-deployment')
     }
 
-    Lambda_Permission(:SftpIdentityProvidorLambdaPermission) {
+    Lambda_Permission(:SftpIdentityProviderLambdaPermission) {
       Action 'lambda:invokeFunction'
-      FunctionName Ref('SftpIdentityProvidor')
+      FunctionName Ref('SftpIdentityProvider')
       Principal 'apigateway.amazonaws.com'
       SourceArn FnSub("arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${CustomIdentityProviderApi}/*")
     }
@@ -161,7 +161,7 @@ CloudFormation do
       Integration({
         Type: 'AWS',
         IntegrationHttpMethod: 'POST',
-        Uri: FnJoin('',['arn:aws:apigateway:', Ref('AWS::Region'), ':lambda:path/2015-03-31/functions/', FnGetAtt(:SftpIdentityProvidor, :Arn), '/invocations']),
+        Uri: FnJoin('',['arn:aws:apigateway:', Ref('AWS::Region'), ':lambda:path/2015-03-31/functions/', FnGetAtt(:SftpIdentityProvider, :Arn), '/invocations']),
         IntegrationResponses: [
           { StatusCode: 200 }
         ],
@@ -315,11 +315,11 @@ CloudFormation do
     if apigateway_endpoint.upcase == 'VPC_ENDPOINT' and identity_provider.upcase == 'API_GATEWAY'
 
       api_sg_tags = default_tags.map(&:clone)
-      api_sg_tags << { Key: "Name", Value: FnSub("${EnvironmentName}-api-gateway-sftp-identidy-providor") }
+      api_sg_tags << { Key: "Name", Value: FnSub("${EnvironmentName}-api-gateway-sftp-identidy-provider") }
 
       EC2_SecurityGroup(:ApiGatewaySecurityGroup) {
         VpcId Ref(:VpcId)
-        GroupDescription FnSub("Controll https access to the ${EnvironmentName} api gateway sftp identity providor vpc endpoint")
+        GroupDescription FnSub("Controll https access to the ${EnvironmentName} api gateway sftp identity provider vpc endpoint")
         SecurityGroupIngress [{
           SourceSecurityGroupId: Ref(:SftpSecurityGroup),
           Description: "SFTP VPC Endpoint Security Group Id",
@@ -444,7 +444,7 @@ CloudFormation do
         InvocationRole: FnGetAtt(:TransferIdentityProviderRole, :Arn),
         Url: FnSub("https://${CustomIdentityProviderApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}")
       })
-      sftp_tags << { Key: 'IdentityProvidorUrl', Value: FnSub("https://${CustomIdentityProviderApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}") }
+      sftp_tags << { Key: 'IdentityProviderUrl', Value: FnSub("https://${CustomIdentityProviderApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}") }
     end
 
     LoggingRole FnGetAtt('SftpServerLoggingRole','Arn')

--- a/sftp.config.yaml
+++ b/sftp.config.yaml
@@ -153,7 +153,8 @@ dynamic_users_create_and_cleanup:
           Ref: EnvironmentName
         USER_CREATED_SNS_TOPIC:
           Ref: DynamicSftpUserCreatedTopic
-        MESSAGE_S3_PATH: ${S3Message}
+        MESSAGE_S3_PATH: 
+          Ref: S3Message
         
     CleanupDynamicSftpUsers:
       code: cleanup_dynamic_sftp_users/index.py

--- a/sftp.config.yaml
+++ b/sftp.config.yaml
@@ -32,7 +32,7 @@ output_vpc_endpoint_ips: false
 # set the format of the hosted zone fo the sftp CNAME record using parameters
 dns_format: ${EnvironmentName}.${DnsDomain}
 
-apigateway_identity_providor:
+apigateway_identity_provider:
   custom_policies:
     get-secrets:
       action:
@@ -40,18 +40,18 @@ apigateway_identity_providor:
       resource:
         Fn::Sub: arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sftp/${EnvironmentName}/*
   roles:
-    SftpIdentityProvidor:
+    SftpIdentityProvider:
       policies_inline:
         - cloudwatch-logs
         - get-secrets
   functions:
-    SftpIdentityProvidor:
+    SftpIdentityProvider:
       named: true
       code: identity_provider/index.py
       handler: index.handler
       runtime: python3.7
       timeout: 30
-      role: SftpIdentityProvidor
+      role: SftpIdentityProvider
       log_retention: 90
       environment:
         ENVIRONMENT_NAME:
@@ -153,6 +153,8 @@ dynamic_users_create_and_cleanup:
           Ref: EnvironmentName
         USER_CREATED_SNS_TOPIC:
           Ref: DynamicSftpUserCreatedTopic
+        MESSAGE_S3_PATH: ${S3Message}
+        
     CleanupDynamicSftpUsers:
       code: cleanup_dynamic_sftp_users/index.py
       handler: index.handler

--- a/spec/dynamic_users_spec.rb
+++ b/spec/dynamic_users_spec.rb
@@ -21,7 +21,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Name" do
-          expect(resource["Properties"]["Name"]).to eq({"Fn::Sub"=>"${EnvironmentName}-sftp-custom-identity-providor"})
+          expect(resource["Properties"]["Name"]).to eq({"Fn::Sub"=>"${EnvironmentName}-sftp-custom-identity-provider"})
       end
       
       it "to have property FailOnWarnings" do
@@ -152,8 +152,8 @@ describe 'compiled component sftp' do
       
     end
     
-    context "SftpIdentityProvidorLambdaPermission" do
-      let(:resource) { template["Resources"]["SftpIdentityProvidorLambdaPermission"] }
+    context "SftpIdentityProviderLambdaPermission" do
+      let(:resource) { template["Resources"]["SftpIdentityProviderLambdaPermission"] }
 
       it "is of type AWS::Lambda::Permission" do
           expect(resource["Type"]).to eq("AWS::Lambda::Permission")
@@ -164,7 +164,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property FunctionName" do
-          expect(resource["Properties"]["FunctionName"]).to eq({"Ref"=>"SftpIdentityProvidor"})
+          expect(resource["Properties"]["FunctionName"]).to eq({"Ref"=>"SftpIdentityProvider"})
       end
       
       it "to have property Principal" do
@@ -298,7 +298,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Integration" do
-          expect(resource["Properties"]["Integration"]).to eq({"Type"=>"AWS", "IntegrationHttpMethod"=>"POST", "Uri"=>{"Fn::Join"=>["", ["arn:aws:apigateway:", {"Ref"=>"AWS::Region"}, ":lambda:path/2015-03-31/functions/", {"Fn::GetAtt"=>["SftpIdentityProvidor", "Arn"]}, "/invocations"]]}, "IntegrationResponses"=>[{"StatusCode"=>200}], "RequestTemplates"=>{"application/json"=>"{\"username\":\"$input.params('username')\",\"password\":\"$input.params('Password')\",\"serverId\":\"$input.params('serverId')\"}"}})
+          expect(resource["Properties"]["Integration"]).to eq({"Type"=>"AWS", "IntegrationHttpMethod"=>"POST", "Uri"=>{"Fn::Join"=>["", ["arn:aws:apigateway:", {"Ref"=>"AWS::Region"}, ":lambda:path/2015-03-31/functions/", {"Fn::GetAtt"=>["SftpIdentityProvider", "Arn"]}, "/invocations"]]}, "IntegrationResponses"=>[{"StatusCode"=>200}], "RequestTemplates"=>{"application/json"=>"{\"username\":\"$input.params('username')\",\"password\":\"$input.params('Password')\",\"serverId\":\"$input.params('serverId')\"}"}})
       end
       
       it "to have property RequestParameters" do
@@ -478,7 +478,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Tags" do
-          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}, {"Key"=>"Name", "Value"=>{"Fn::Sub"=>"sftp-${EnvironmentName}"}}, {"Key"=>"IdentityProvidorUrl", "Value"=>{"Fn::Sub"=>"https://${CustomIdentityProviderApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}"}}])
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}, {"Key"=>"Name", "Value"=>{"Fn::Sub"=>"sftp-${EnvironmentName}"}}, {"Key"=>"IdentityProviderUrl", "Value"=>{"Fn::Sub"=>"https://${CustomIdentityProviderApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}"}}])
       end
       
     end
@@ -516,8 +516,8 @@ describe 'compiled component sftp' do
       
     end
     
-    context "LambdaRoleSftpIdentityProvidor" do
-      let(:resource) { template["Resources"]["LambdaRoleSftpIdentityProvidor"] }
+    context "LambdaRoleSftpIdentityProvider" do
+      let(:resource) { template["Resources"]["LambdaRoleSftpIdentityProvider"] }
 
       it "is of type AWS::IAM::Role" do
           expect(resource["Type"]).to eq("AWS::IAM::Role")
@@ -537,8 +537,8 @@ describe 'compiled component sftp' do
       
     end
     
-    context "SftpIdentityProvidor" do
-      let(:resource) { template["Resources"]["SftpIdentityProvidor"] }
+    context "SftpIdentityProvider" do
+      let(:resource) { template["Resources"]["SftpIdentityProvider"] }
 
       it "is of type AWS::Lambda::Function" do
           expect(resource["Type"]).to eq("AWS::Lambda::Function")
@@ -557,7 +557,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Role" do
-          expect(resource["Properties"]["Role"]).to eq({"Fn::GetAtt"=>["LambdaRoleSftpIdentityProvidor", "Arn"]})
+          expect(resource["Properties"]["Role"]).to eq({"Fn::GetAtt"=>["LambdaRoleSftpIdentityProvider", "Arn"]})
       end
       
       it "to have property Runtime" do
@@ -569,20 +569,20 @@ describe 'compiled component sftp' do
       end
       
       it "to have property FunctionName" do
-          expect(resource["Properties"]["FunctionName"]).to eq("SftpIdentityProvidor")
+          expect(resource["Properties"]["FunctionName"]).to eq("SftpIdentityProvider")
       end
       
     end
     
-    context "SftpIdentityProvidorLogGroup" do
-      let(:resource) { template["Resources"]["SftpIdentityProvidorLogGroup"] }
+    context "SftpIdentityProviderLogGroup" do
+      let(:resource) { template["Resources"]["SftpIdentityProviderLogGroup"] }
 
       it "is of type AWS::Logs::LogGroup" do
           expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
       end
       
       it "to have property LogGroupName" do
-          expect(resource["Properties"]["LogGroupName"]).to eq("/aws/lambda/SftpIdentityProvidor")
+          expect(resource["Properties"]["LogGroupName"]).to eq("/aws/lambda/SftpIdentityProvider")
       end
       
       it "to have property RetentionInDays" do

--- a/spec/identity_provider_spec.rb
+++ b/spec/identity_provider_spec.rb
@@ -4,11 +4,11 @@ describe 'compiled component sftp' do
   
   context 'cftest' do
     it 'compiles test' do
-      expect(system("cfhighlander cftest #{@validate} --tests tests/identity_providor.test.yaml")).to be_truthy
+      expect(system("cfhighlander cftest #{@validate} --tests tests/identity_provider.test.yaml")).to be_truthy
     end      
   end
   
-  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/identity_providor/sftp.compiled.yaml") }
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/identity_provider/sftp.compiled.yaml") }
   
   context "Resource" do
 
@@ -21,7 +21,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Name" do
-          expect(resource["Properties"]["Name"]).to eq({"Fn::Sub"=>"${EnvironmentName}-sftp-custom-identity-providor"})
+          expect(resource["Properties"]["Name"]).to eq({"Fn::Sub"=>"${EnvironmentName}-sftp-custom-identity-provider"})
       end
       
       it "to have property FailOnWarnings" do
@@ -152,8 +152,8 @@ describe 'compiled component sftp' do
       
     end
     
-    context "SftpIdentityProvidorLambdaPermission" do
-      let(:resource) { template["Resources"]["SftpIdentityProvidorLambdaPermission"] }
+    context "SftpIdentityProviderLambdaPermission" do
+      let(:resource) { template["Resources"]["SftpIdentityProviderLambdaPermission"] }
 
       it "is of type AWS::Lambda::Permission" do
           expect(resource["Type"]).to eq("AWS::Lambda::Permission")
@@ -164,7 +164,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property FunctionName" do
-          expect(resource["Properties"]["FunctionName"]).to eq({"Ref"=>"SftpIdentityProvidor"})
+          expect(resource["Properties"]["FunctionName"]).to eq({"Ref"=>"SftpIdentityProvider"})
       end
       
       it "to have property Principal" do
@@ -298,7 +298,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Integration" do
-          expect(resource["Properties"]["Integration"]).to eq({"Type"=>"AWS", "IntegrationHttpMethod"=>"POST", "Uri"=>{"Fn::Join"=>["", ["arn:aws:apigateway:", {"Ref"=>"AWS::Region"}, ":lambda:path/2015-03-31/functions/", {"Fn::GetAtt"=>["SftpIdentityProvidor", "Arn"]}, "/invocations"]]}, "IntegrationResponses"=>[{"StatusCode"=>200}], "RequestTemplates"=>{"application/json"=>"{\"username\":\"$input.params('username')\",\"password\":\"$input.params('Password')\",\"serverId\":\"$input.params('serverId')\"}"}})
+          expect(resource["Properties"]["Integration"]).to eq({"Type"=>"AWS", "IntegrationHttpMethod"=>"POST", "Uri"=>{"Fn::Join"=>["", ["arn:aws:apigateway:", {"Ref"=>"AWS::Region"}, ":lambda:path/2015-03-31/functions/", {"Fn::GetAtt"=>["SftpIdentityProvider", "Arn"]}, "/invocations"]]}, "IntegrationResponses"=>[{"StatusCode"=>200}], "RequestTemplates"=>{"application/json"=>"{\"username\":\"$input.params('username')\",\"password\":\"$input.params('Password')\",\"serverId\":\"$input.params('serverId')\"}"}})
       end
       
       it "to have property RequestParameters" do
@@ -389,7 +389,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Tags" do
-          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}, {"Key"=>"Name", "Value"=>{"Fn::Sub"=>"sftp-${EnvironmentName}"}}, {"Key"=>"IdentityProvidorUrl", "Value"=>{"Fn::Sub"=>"https://${CustomIdentityProviderApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}"}}])
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}, {"Key"=>"Name", "Value"=>{"Fn::Sub"=>"sftp-${EnvironmentName}"}}, {"Key"=>"IdentityProviderUrl", "Value"=>{"Fn::Sub"=>"https://${CustomIdentityProviderApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}"}}])
       end
       
     end
@@ -511,8 +511,8 @@ describe 'compiled component sftp' do
       
     end
     
-    context "LambdaRoleSftpIdentityProvidor" do
-      let(:resource) { template["Resources"]["LambdaRoleSftpIdentityProvidor"] }
+    context "LambdaRoleSftpIdentityProvider" do
+      let(:resource) { template["Resources"]["LambdaRoleSftpIdentityProvider"] }
 
       it "is of type AWS::IAM::Role" do
           expect(resource["Type"]).to eq("AWS::IAM::Role")
@@ -532,8 +532,8 @@ describe 'compiled component sftp' do
       
     end
     
-    context "SftpIdentityProvidor" do
-      let(:resource) { template["Resources"]["SftpIdentityProvidor"] }
+    context "SftpIdentityProvider" do
+      let(:resource) { template["Resources"]["SftpIdentityProvider"] }
 
       it "is of type AWS::Lambda::Function" do
           expect(resource["Type"]).to eq("AWS::Lambda::Function")
@@ -552,7 +552,7 @@ describe 'compiled component sftp' do
       end
       
       it "to have property Role" do
-          expect(resource["Properties"]["Role"]).to eq({"Fn::GetAtt"=>["LambdaRoleSftpIdentityProvidor", "Arn"]})
+          expect(resource["Properties"]["Role"]).to eq({"Fn::GetAtt"=>["LambdaRoleSftpIdentityProvider", "Arn"]})
       end
       
       it "to have property Runtime" do
@@ -564,20 +564,20 @@ describe 'compiled component sftp' do
       end
       
       it "to have property FunctionName" do
-          expect(resource["Properties"]["FunctionName"]).to eq("SftpIdentityProvidor")
+          expect(resource["Properties"]["FunctionName"]).to eq("SftpIdentityProvider")
       end
       
     end
     
-    context "SftpIdentityProvidorLogGroup" do
-      let(:resource) { template["Resources"]["SftpIdentityProvidorLogGroup"] }
+    context "SftpIdentityProviderLogGroup" do
+      let(:resource) { template["Resources"]["SftpIdentityProviderLogGroup"] }
 
       it "is of type AWS::Logs::LogGroup" do
           expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
       end
       
       it "to have property LogGroupName" do
-          expect(resource["Properties"]["LogGroupName"]).to eq("/aws/lambda/SftpIdentityProvidor")
+          expect(resource["Properties"]["LogGroupName"]).to eq("/aws/lambda/SftpIdentityProvider")
       end
       
       it "to have property RetentionInDays" do

--- a/tests/dynamic_users.test.yaml
+++ b/tests/dynamic_users.test.yaml
@@ -1,7 +1,7 @@
 test_metadata:
   type: config
   name: dynamic_users
-  description: test dynamic users for api_gateway identity providor
+  description: test dynamic users for api_gateway identity provider
 
 identity_provider: API_GATEWAY
 

--- a/tests/identity_provider.test.yaml
+++ b/tests/identity_provider.test.yaml
@@ -1,7 +1,7 @@
 test_metadata:
   type: config
-  name: identity_providor
-  description: test the apigateway identity providor
+  name: identity_provider
+  description: test the apigateway identity provider
 
 identity_provider: API_GATEWAY
 


### PR DESCRIPTION
@Guslington I'm not sure if there's a better way to just 'append' the S3 inline policy, without specifying the _entire_ config again (see README for what I mean), I did try multiple variations of of the yaml variables you mentioned on Slack, but couldn't get it working.